### PR TITLE
Add dotenv support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Natural Language Databasing. Talk to your data in English, via CLI, API or a sim
 pip install nldb
 ```
 
-An OpenAI API key should be available as the `OPENAI_API_KEY` environment variable, e.g. using `export OPENAI_API_KEY=sk-etc`.
+An OpenAI API key should be available as the `OPENAI_API_KEY` environment variable, e.g. using `export OPENAI_API_KEY=sk-etc` or adding it to your project `.env` file.
 
 ## Preparing your database
 NLDB can talk to SQLite and DuckDB databases. Call yours `nldb.db` or specify the name with a `DATABASE` environment variable.

--- a/nldb/api.py
+++ b/nldb/api.py
@@ -1,4 +1,3 @@
-import os
 from typing import Union
 
 import uvicorn
@@ -7,9 +6,8 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel
 
 from nldb.core import NLDB
+from nldb.config import UVICORN_HOST, UVICORN_PORT
 
-UVICORN_HOST = os.environ.get("UVICORN_HOST", "0.0.0.0")
-UVICORN_PORT = int(os.environ.get("UVICORN_PORT", 8080))
 
 app = FastAPI()
 

--- a/nldb/cli.py
+++ b/nldb/cli.py
@@ -5,7 +5,8 @@ from typing import Optional
 
 import typer
 from nldb.api import serve
-from nldb.core import DATABASE, NLDB
+from nldb.core import NLDB
+from nldb.config import DATABASE, OPENAI_API_KEY
 
 
 def preflight_checks():
@@ -18,7 +19,7 @@ def preflight_checks():
     if not os.path.exists(DATABASE):
         typer.echo(f"Database file not found: {DATABASE}")
         failures += 1
-    if not os.environ.get("OPENAI_API_KEY"):
+    if not OPENAI_API_KEY:
         typer.echo("OPENAI_API_KEY environment variable not set")
         failures += 1
     if failures > 0:
@@ -44,7 +45,7 @@ def init():
 
 def deploy_instructions():
     typer.echo("Printing deployment instructions")
-    openai_api_key = os.environ.get("OPENAI_API_KEY", "your OpenAI API key")
+    openai_api_key = OPENAI_API_KEY or "your OpenAI API key"
     instructions = inspect.cleandoc(
         f"""
         # For fly.io:

--- a/nldb/config.py
+++ b/nldb/config.py
@@ -1,0 +1,9 @@
+import os
+from dotenv import load_dotenv
+
+load_dotenv()
+
+DATABASE = os.getenv("DATABASE", "nldb.db")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+UVICORN_HOST = os.getenv("UVICORN_HOST", "0.0.0.0")
+UVICORN_PORT = int(os.getenv("UVICORN_PORT", 8080))

--- a/nldb/core.py
+++ b/nldb/core.py
@@ -12,7 +12,7 @@ import duckdb
 import openai
 from tabulate import tabulate
 
-DATABASE = os.environ.get("DATABASE", "nldb.db")
+from nldb.config import DATABASE
 
 
 class ttimer:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "typer",
     "duckdb",
     "matplotlib",
+    "python-dotenv"
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR adds [python-dotenv](https://pypi.org/project/python-dotenv/) as a dependency to support `.env` files as I consistently fail to run `export ...`