### PR TITLE
Specify dotenv_path for load_dotenv to avoid searching for it in parent dirs

### DIFF
--- a/nldb/config.py
+++ b/nldb/config.py
@@ -1,7 +1,7 @@
 import os
 from dotenv import load_dotenv
 
-load_dotenv()
+load_dotenv(dotenv_path=".env")
 
 DATABASE = os.getenv("DATABASE", "nldb.db")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")


### PR DESCRIPTION
Follow up for #2