### PR TITLE
Refactor caching

### DIFF
--- a/nldb/cache/__init__.py
+++ b/nldb/cache/__init__.py
@@ -1,0 +1,21 @@
+from functools import wraps
+from typing import Optional
+
+from .file import FileCache
+
+
+def cache(cache_dir: Optional[str], ttl: int):
+    def decorator(func):
+        file_cache = FileCache(cache_dir=cache_dir, ttl=ttl)
+
+        @wraps(func)
+        async def wrapper(self, key: str, *args, **kwargs):
+            if (value := file_cache.get(key)) is None:
+                value = await func(self, *args, **kwargs)
+                await file_cache.set(key, value, ttl=ttl)
+
+            return value
+
+        return wrapper
+
+    return decorator

--- a/nldb/cache/__init__.py
+++ b/nldb/cache/__init__.py
@@ -1,21 +1,7 @@
-from functools import wraps
-from typing import Optional
+from nldb.config import get_settings
 
 from .file import FileCache
 
+settings = get_settings()
 
-def cache(cache_dir: Optional[str], ttl: int):
-    def decorator(func):
-        file_cache = FileCache(cache_dir=cache_dir, ttl=ttl)
-
-        @wraps(func)
-        async def wrapper(self, key: str, *args, **kwargs):
-            if (value := file_cache.get(key)) is None:
-                value = await func(self, *args, **kwargs)
-                await file_cache.set(key, value, ttl=ttl)
-
-            return value
-
-        return wrapper
-
-    return decorator
+cache = FileCache(cache_dir=settings.cache_dir, ttl=settings.cache_ttl)

--- a/nldb/cache/base.py
+++ b/nldb/cache/base.py
@@ -1,15 +1,15 @@
-from typing import Optional, Protocol, TypeVar, runtime_checkable
+from typing import Protocol, TypeVar, runtime_checkable
 
 T = TypeVar("T", bound="CacheBackend")
 
 
 @runtime_checkable
 class CacheBackend(Protocol):
-    def get(self: T, key: str) -> Optional[bytes]:
+    def get(self: T, key: str) -> bytes | None:
         ...
 
-    def set(self: T, key: str, value: bytes, ttl: Optional[int] = None) -> None:
+    def set(self: T, key: str, value: bytes, ttl: int | None = None) -> None:
         ...
 
-    def clear(self: T, key: Optional[str] = None) -> None:
+    def clear(self: T, key: str | None = None) -> None:
         ...

--- a/nldb/cache/base.py
+++ b/nldb/cache/base.py
@@ -1,0 +1,15 @@
+from typing import Optional, Protocol, TypeVar, runtime_checkable
+
+T = TypeVar("T", bound="CacheBackend")
+
+
+@runtime_checkable
+class CacheBackend(Protocol):
+    def get(self: T, key: str) -> Optional[bytes]:
+        ...
+
+    def set(self: T, key: str, value: bytes, ttl: Optional[int] = None) -> None:
+        ...
+
+    def clear(self: T, key: Optional[str] = None) -> None:
+        ...

--- a/nldb/cache/file.py
+++ b/nldb/cache/file.py
@@ -1,0 +1,56 @@
+import json
+import time
+from pathlib import Path
+from typing import Optional
+
+from .base import CacheBackend
+
+
+class FileCache(CacheBackend):
+    def __init__(
+        self, cache_dir: Optional[str] = "cache", ttl: Optional[int] = None
+    ) -> None:
+        self.cache_dir = Path(cache_dir)
+        self.ttl = ttl
+
+        # ensure the cache directory exists
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+
+    def _get_cache_path(self, key: str) -> Path:
+        return self.cache_dir / f"{key}.json"
+
+    def _is_cache_expired(self, cache_path: Path) -> bool:
+        """
+        Checks whether a given cache file is expired.
+        """
+        if not self.ttl:
+            # if ttl is not set, cache never expires
+            return False
+
+        modified_time = cache_path.stat().st_mtime
+        current_time = time.time()
+        return current_time - modified_time > self.ttl
+
+    def get(self, key: str) -> Optional[bytes]:
+        """
+        Returns the cached value for the given key, if it exists and is not expired.
+        """
+        cache_path = self._get_cache_path(key)
+        if cache_path.is_file() and not self._is_cache_expired(cache_path):
+            return json.loads(cache_path.read_text())
+        return None
+
+    def set(self, key: str, value: bytes, ttl: Optional[int] = None) -> None:
+        cache_path = self._get_cache_path(key)
+        cache_path.write_text(str(value))
+
+    def clear(self, key: Optional[str] = None) -> None:
+        """
+        Clears the cache.
+        If key is specified, only the cached file for that key is cleared.
+        """
+        if key:
+            if (cache_path := self._get_cache_path(key)) and cache_path.is_file():
+                cache_path.unlink()
+        else:
+            self.cache_dir.rmdir()

--- a/nldb/cache/file.py
+++ b/nldb/cache/file.py
@@ -2,15 +2,12 @@ import hashlib
 import json
 import time
 from pathlib import Path
-from typing import Optional
 
 from .base import CacheBackend
 
 
 class FileCache(CacheBackend):
-    def __init__(
-        self, cache_dir: Optional[str] = None, ttl: Optional[int] = None
-    ) -> None:
+    def __init__(self, cache_dir: str | None = None, ttl: int | None = None) -> None:
         self.cache_dir = Path(cache_dir or "cache")
         self.ttl = ttl
 
@@ -39,7 +36,7 @@ class FileCache(CacheBackend):
         current_time = time.time()
         return current_time - modified_time > self.ttl
 
-    def get(self, key: str) -> Optional[bytes]:
+    def get(self, key: str) -> bytes | None:
         """
         Returns the cached value for the given key, if it exists and is not expired.
         """
@@ -53,11 +50,11 @@ class FileCache(CacheBackend):
                 return None
         return None
 
-    def set(self, key: str, value: bytes, ttl: Optional[int] = None) -> None:
+    def set(self, key: str, value: bytes, ttl: int | None = None) -> None:
         cache_path = self._get_cache_path(key)
         cache_path.write_text(str(value))
 
-    def clear(self, key: Optional[str] = None) -> None:
+    def clear(self, key: str | None = None) -> None:
         """
         Clears the cache.
         If key is specified, only the cached file for that key is cleared.

--- a/nldb/cache/file.py
+++ b/nldb/cache/file.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import time
 from pathlib import Path
@@ -8,16 +9,23 @@ from .base import CacheBackend
 
 class FileCache(CacheBackend):
     def __init__(
-        self, cache_dir: Optional[str] = "cache", ttl: Optional[int] = None
+        self, cache_dir: Optional[str] = None, ttl: Optional[int] = None
     ) -> None:
-        self.cache_dir = Path(cache_dir)
+        self.cache_dir = Path(cache_dir or "cache")
         self.ttl = ttl
 
         # ensure the cache directory exists
         self.cache_dir.mkdir(parents=True, exist_ok=True)
 
+    def _hash_key(self, key: str) -> str:
+        """
+        Hashes the given key.
+        """
+        return hashlib.sha256(str(key).encode("utf-8")).hexdigest()
+
     def _get_cache_path(self, key: str) -> Path:
-        return self.cache_dir / f"{key}.json"
+        hashed_key = self._hash_key(key)
+        return self.cache_dir / f"{hashed_key}.json"
 
     def _is_cache_expired(self, cache_path: Path) -> bool:
         """
@@ -37,7 +45,12 @@ class FileCache(CacheBackend):
         """
         cache_path = self._get_cache_path(key)
         if cache_path.is_file() and not self._is_cache_expired(cache_path):
-            return json.loads(cache_path.read_text())
+            try:
+                return json.loads(cache_path.read_text())
+            except json.JSONDecodeError:
+                # if the cache file is corrupted, delete it
+                cache_path.unlink()
+                return None
         return None
 
     def set(self, key: str, value: bytes, ttl: Optional[int] = None) -> None:

--- a/nldb/config.py
+++ b/nldb/config.py
@@ -8,6 +8,8 @@ class Settings(BaseSettings):
     openai_api_key: str = None
     uvicorn_host: str = "0.0.0.0"  # noqa: S104
     uvicorn_port: int = 8080
+    cache_dir: str = "cache"
+    cache_ttl: int = 60 * 60 * 24  # 1 day
 
     class Config:
         env_file = ".env"


### PR DESCRIPTION
Builds on #7, Fixes #5

Introduces a generic cache backend type, implements file cache with ttl, cache purging

Tasks:
- [x] TTLs
- [x] cache purging
- [ ] non-file backends (e.g. Redis?)
- [ ] simple input normalisation (e.g. spacing)
- [ ] consider using https://github.com/aio-libs/aiocache
